### PR TITLE
fixed dsh parsing bug and support for username@host

### DIFF
--- a/cssh.el
+++ b/cssh.el
@@ -294,7 +294,7 @@ remote hosts list"
     (let ((l     (split-string (buffer-string)))
 	  (hosts))
       (dolist (elt l)
-	(when (looking-at (rx bol (opt "@") (one-or-more (char alnum ".-")) eol))
+	(when (string-match (rx bol (opt "@") (one-or-more (char alnum ".-@")) eol) elt)
 	  (if (string-match "^@" elt)
 	      (mapc (lambda (x) (add-to-list 'hosts x))
 		    (cssh-parse-dsh-config-file

--- a/cssh.el
+++ b/cssh.el
@@ -294,7 +294,7 @@ remote hosts list"
     (let ((l     (split-string (buffer-string)))
 	  (hosts))
       (dolist (elt l)
-	(when (string-match (rx bol (opt "@") (one-or-more (char alnum ".-@")) eol) elt)
+	(when (string-match (rx bol (opt "@") (one-or-more (char alnum ".-@\\")) eol) elt)
 	  (if (string-match "^@" elt)
 	      (mapc (lambda (x) (add-to-list 'hosts x))
 		    (cssh-parse-dsh-config-file


### PR DESCRIPTION
we should use string-match instead of looking-at, since we need to match against the current element, not the position of the point in the buffer.  

Also, added @ to the set of allowable characters to support lines of the form
`domain\username@host`
